### PR TITLE
fix(pipeline): add $ and quotes to 3dcalc command in line 154

### DIFF
--- a/pipelines/pipeline.sh
+++ b/pipelines/pipeline.sh
@@ -151,7 +151,7 @@ if [[ "$SUBJ_LEVEL_PREPROC" == "yes" ]]; then
 			spm_segment ${MEAN_EPI_DATA_VOL} ${SEGMENT_AFF_REG} ${SEGMENT_SAVE_OUTPUTS_BIAS_FIELD} ${subj}_spm_segment_bias_field 1
 			echo "${subj} inhomogeneity correction - mean EPI segmentation done."
 			for ((run=0; run<${#NVOLS_RUN[@]}; run++ )); do
-				3dcalc -a EPI_(( run + 1))_filename.nii -b BIAS_FIELD_VOL.nii -expr 'a*b' -prefix bEPI_(( run + 1))_filename.nii
+				3dcalc -a "EPI_$(( run + 1 ))_filename.nii" -b "BIAS_FIELD_VOL.nii" -expr 'a*b' -prefix "bEPI_$(( run + 1 ))_filename.nii"
 			done
 			echo "${subj} inhomogeneity correction done."
 		fi


### PR DESCRIPTION
## Summary

Fix AFNI 3dcalc command on line 154 of `pipelines/pipeline.sh`:
- `EPI_(( run + 1))` → `EPI_$(( run + 1 ))` (missing `$` and spaces in arithmetic expression)
- Add double quotes around filename arguments per AFNI syntax

## Changes

- **File**: `pipelines/pipeline.sh` line 154
- **Before**: `3dcalc -a EPI_(( run + 1))_filename.nii -b BIAS_FIELD_VOL.nii ...`
- **After**: `3dcalc -a "EPI_$(( run + 1 ))_filename.nii" -b "BIAS_FIELD_VOL.nii" ...`
- **Lines changed**: 1 (1 file)

## Fixes

Fixes #6